### PR TITLE
Optimize interior generation

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisInteriorManager.java
@@ -285,6 +285,7 @@ public class TardisInteriorManager {
     }
 
     public void generateDesktop(DesktopTheme theme) {
+        DesktopTheme oldTheme = this.currentTheme;
         setCurrentTheme(theme);
         // Has generated before.
         if (this.operator.getInternalDoor() != null) {
@@ -299,7 +300,7 @@ public class TardisInteriorManager {
         }
 
         if (operator.getLevel() instanceof ServerLevel serverLevel) {
-            TardisArchitectureHandler.generateDesktop(serverLevel, theme);
+            TardisArchitectureHandler.generateDesktop(serverLevel, theme, oldTheme);
         }
     }
 


### PR DESCRIPTION
When generating an interior, it takes ~7-8 seconds to generate. By running a Spark profiler, the longest function run was setBlock. I have modified the logic to only fill in the blocks that the previous interior occupied. Lowering times to around ~2.25 seconds. Not perfect, but certainly an improvement.

I would like someone to make sure that the airlock correction works properly as well, if not please adjust as needed.