### PR TITLE
Exposing more functions

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisFlightEventManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisFlightEventManager.java
@@ -96,14 +96,14 @@ public class TardisFlightEventManager {
     /*
     * Is a prompt still within the combo time.
     * */
-    private boolean isEventInComboTime() {
+    public boolean isEventInComboTime() {
         return (this.ticksSincePrompted < 3 * 20);
     }
 
     /*
     * Get the current remaining ticks of cooldown between two controls.
     * */
-    private int getControlRequestCooldown() {
+    public int getControlRequestCooldown() {
         return (isEventInComboTime() ? 20 : 60);  // This will be expanded on when Stats are added.
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -293,6 +293,10 @@ public class TardisPilotingManager {
         return new BlockPos(pos.getX(), originalY, pos.getZ());
     }
 
+    /** Checks the tardis nav location for a variety of reasons that a given position would be unsafe to land at.
+     * @param location the coordinates to check against
+     * @return true if safe to land, otherwise false
+     */
     public boolean isSafeToLand(TardisNavLocation location)
     {
         if (!isSolidBlock(location.getLevel(), location.getPosition()) && isSolidBlock(location.getLevel(), location.getPosition().below()) && !isSolidBlock(location.getLevel(), location.getPosition().above())) {

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -77,10 +77,20 @@ public class TardisPilotingManager {
         return (ticksSinceCrash > 0);
     }
 
+    /**
+     * Accessor for the number of ticks since the Tardis crashed.
+     * @return private field ticksSinceCrash
+     */
     public int getCooldownTicks() {
         return ticksSinceCrash;
     }
 
+
+    /**
+     * A progress value after crashing that determines how long until cooldown has finished.
+     * Zero means it has only started, 1 means that cooldown has finished.
+     * @return a percentage value between 0 - 1.
+     */
     public int getCooldownDuration() {
         return ticksSinceCrash / TICKS_COOLDOWN_MAX;
     }
@@ -492,6 +502,9 @@ public class TardisPilotingManager {
         return this.targetLocation;
     }
 
+    /**
+     * @return the current fast return location
+     */
     public TardisNavLocation getFastReturnLocation() {
         return this.fastReturnLocation;
     }

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -293,7 +293,7 @@ public class TardisPilotingManager {
         return new BlockPos(pos.getX(), originalY, pos.getZ());
     }
 
-    private boolean isSafeToLand(TardisNavLocation location)
+    public boolean isSafeToLand(TardisNavLocation location)
     {
         if (!isSolidBlock(location.getLevel(), location.getPosition()) && isSolidBlock(location.getLevel(), location.getPosition().below()) && !isSolidBlock(location.getLevel(), location.getPosition().above())) {
             return !location.getLevel().getBlockState(location.getPosition().below()).getFluidState().is(FluidTags.LAVA) && !location.getLevel().getBlockState(location.getPosition().below()).getFluidState().is(FluidTags.WATER);

--- a/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/tardis/manager/TardisPilotingManager.java
@@ -77,6 +77,14 @@ public class TardisPilotingManager {
         return (ticksSinceCrash > 0);
     }
 
+    public int getCooldownTicks() {
+        return ticksSinceCrash;
+    }
+
+    public int getCooldownDuration() {
+        return ticksSinceCrash / TICKS_COOLDOWN_MAX;
+    }
+
     public void endCoolDown() {
         this.ticksSinceCrash = TICKS_COOLDOWN_MAX;
     }
@@ -482,6 +490,10 @@ public class TardisPilotingManager {
 
     public TardisNavLocation getTargetLocation() {
         return this.targetLocation;
+    }
+
+    public TardisNavLocation getFastReturnLocation() {
+        return this.fastReturnLocation;
     }
 
     public void setTargetLocation(TardisNavLocation targetLocation) {


### PR DESCRIPTION
## Changes Proposed
Adding getters for the following:
- Fast return location - The last known location that a tardis was set to before beginning flight.
- Cooldown Ticks - the number of ticks that has passed since crashing.
- Cooldown duration - exposing how long until the tardis has finished cooling down after a crash
- isEventInComboTime - let a user know they can get a bonus for successfully completing an event before the combo timer is up
- getControlRequestCooldown - Get the current remaining ticks of cooldown between two controls, so they can know their grace period.

## Why
I would like these to have public accessors, to provide more information to the user in a ComputerCraft peripheral. More information is always a positive thing ♥