### PR TITLE
Prevent Auto Jump making you miss the immersive portal

### DIFF
--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/GlobalShellBlock.java
@@ -43,20 +43,22 @@ public class GlobalShellBlock extends ShellBaseBlock{
         return super.getStateForPlacement(blockPlaceContext).setValue(SHELL, ShellTheme.FACTORY);
     }
 
-    protected static final VoxelShape COLLISION = Block.box(0.0, 0.0, 0.0, 16.0, 8.0, 16.0);
+    //The collision box for the briefcase shell
+    //overrides the default collision shape from ShellBaseBlock.java
+    protected static final VoxelShape BRIEFCASE_COLLISION_SHAPE = Block.box(0.0, 0.0, 0.0, 16.0, 8.0, 16.0);
 
 
     @Override
     public VoxelShape getCollisionShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
         if(blockState.getValue(SHELL) == ShellTheme.BRIEFCASE)
-            return COLLISION;
+            return BRIEFCASE_COLLISION_SHAPE;
         return super.getCollisionShape(blockState, blockGetter, blockPos, collisionContext);
     }
 
     @Override
     public VoxelShape getShape(BlockState blockState, BlockGetter blockGetter, BlockPos blockPos, CollisionContext collisionContext) {
         if(blockState.getValue(SHELL) == ShellTheme.BRIEFCASE)
-            return COLLISION;
+            return BRIEFCASE_COLLISION_SHAPE;
         return super.getShape(blockState, blockGetter, blockPos, collisionContext);
     }
 

--- a/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
+++ b/common/src/main/java/whocraft/tardis_refined/common/block/shell/ShellBaseBlock.java
@@ -32,10 +32,10 @@ public abstract class ShellBaseBlock extends BaseEntityBlock implements SimpleWa
     public static final BooleanProperty REGEN = BooleanProperty.create("regen");
     public static final BooleanProperty LOCKED = BooleanProperty.create("locked");
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
-    protected static final VoxelShape NORTH_AABB = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 20.0D, 11.0D);
-    protected static final VoxelShape SOUTH_AABB = Block.box(0.0D, 0.0D, 2.0D, 16.0D, 20.0D, 16.0D);
-    protected static final VoxelShape WEST_AABB = Block.box(0.0D, 0.0D, 0.0D, 11.0D, 20.0D, 16.0D);
-    protected static final VoxelShape EAST_AABB = Block.box(2.0D, 0.0D, 0.0D, 16.0D, 20.0D, 16.0D);
+    protected static final VoxelShape NORTH_AABB = Block.box(0.0D, 0.0D, 0.0D, 16.0D, 30.0D, 11.0D);
+    protected static final VoxelShape SOUTH_AABB = Block.box(0.0D, 0.0D, 2.0D, 16.0D, 30.0D, 16.0D);
+    protected static final VoxelShape WEST_AABB = Block.box(0.0D, 0.0D, 0.0D, 11.0D,  30.0D, 16.0D);
+    protected static final VoxelShape EAST_AABB = Block.box(2.0D, 0.0D, 0.0D, 16.0D,  30.0D, 16.0D);
 
     public ShellBaseBlock(Properties properties) {
         super(properties);


### PR DESCRIPTION
Minecraft has a default config setting that will auto-jump the player when nearing a block that they can jump on top of. 

This means that when the player is walking towards a Tardis, they will auto jump, landing on top of the collision box (or skipping past the tardis) and miss the immersive portal completely.

Contained commit raises the height of the Tardis block's collision, preventing auto jump from triggering. Does not affect the briefcase shell, as that uses an override specifically for that shell shape.
