### PR TITLE
Fix branch not compiling to allow `gradle build`

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -50,7 +50,9 @@ dependencies {
     modImplementation "curse.maven:configured-457570:${configured_version}"
     modImplementation "curse.maven:jei-238222:${jei_version}"
 
-    // modCompileOnly "curse.maven:immersive-portals-355440:4375619"
+    //_must_ be compileOnly, not modCompileOnly, as the IP forge jar contains fabric related stuff that it isn't expecting for forge
+    //this also means that we cannot test immersive portals in the dev environment, as it wont get correct mappings
+    compileOnly "curse.maven:immersive-portals-355440:${ip_forge_version}"
 
     // With ForgeGradle 5, use the runtimeOnly configuration
     //runtimeOnly("me.djtheredstoner:DevAuth-${dev_auth_module_forge}:${dev_auth_forge_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -72,5 +72,6 @@ world_edit_version=3922622
 structure_expansion_version=3909814
 configured_version=4011355
 jei_version=4239206
+ip_forge_version=4477626
 dev_auth_module_forge=forge-latest
 dev_auth_forge_version=1.1.2


### PR DESCRIPTION
Fixes compile error introduced from #177. 

This pull request unfortunately doesn't allow testing immersive portals in editor, due to the IP forge jar containing fabric related files that architectury is not expecting for forge. This may be fixed in a future architectury version, according to the following commit, but only if it is backported to 1.19.2.
[9f070d2](https://github.com/architectury/architectury-loom/commit/9f070d270fba39ab94321258d9f64a7117a65f26)